### PR TITLE
http4k-jetty-server use non-deprecated method to setup status in Http…

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
@@ -14,6 +14,7 @@ import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.Status
 import org.http4k.core.Status.Companion.ACCEPTED
 import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
 import org.http4k.core.Status.Companion.OK
@@ -66,6 +67,9 @@ abstract class ServerContract(private val serverConfig: (Int) -> ServerConfig, p
                     .header("x-address", request.source?.address ?: "")
                     .header("x-port", (request.source?.port ?: 0).toString())
                     .header("x-scheme", (request.source?.scheme ?: "unsupported").toString())
+            },
+            "/status-with-foobar-description" bind GET to {
+                Response(Status(201, "FooBar"))
             }
         )
 

--- a/http4k-server/jetty/src/main/kotlin/org/http4k/servlet/jakarta/servlet.kt
+++ b/http4k-server/jetty/src/main/kotlin/org/http4k/servlet/jakarta/servlet.kt
@@ -11,9 +11,8 @@ import org.http4k.core.Uri
 import org.http4k.core.safeLong
 import java.util.Enumeration
 
-@Suppress("DEPRECATION")
 fun Response.transferTo(destination: HttpServletResponse) {
-    destination.setStatus(status.code, status.description)
+    destination.setStatus(status.code)
     headers.forEach { (key, value) -> destination.addHeader(key, value) }
     body.stream.use { input -> destination.outputStream.use { output -> input.copyTo(output) } }
 }

--- a/http4k-server/jetty/src/test/kotlin/org/http4k/server/JettyTest.kt
+++ b/http4k-server/jetty/src/test/kotlin/org/http4k/server/JettyTest.kt
@@ -1,8 +1,10 @@
 package org.http4k.server
 
 import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.client.ApacheClient
+import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
@@ -11,6 +13,14 @@ import java.io.File
 
 class JettyTest : ServerContract(::Jetty, ApacheClient()) {
     override fun requestScheme(): Matcher<String?> = equalTo("http")
+
+    @Test
+    fun `returns status with pre-defined standardized description`() {
+        val response = client(Request(Method.GET, "$baseUrl/status-with-foobar-description"))
+
+        assertThat(response.status.code, equalTo(201))
+        assertThat(response.status.description, equalTo("Created"))
+    }
 }
 
 class JettyHttp2Test {


### PR DESCRIPTION
…ServletResponse (#747)

The change allows the use of the latest Jakarta version (jakarta.servlet:jakarta.servlet-api:6.0.0)

Co-authored-by: mandyvuong <mandyvuong@gmail.com>

Co-authored-by: mandyvuong <mandyvuong@gmail.com>